### PR TITLE
Add very numerous bug fixes and features, from Norse Corp.

### DIFF
--- a/src/conn.h
+++ b/src/conn.h
@@ -66,6 +66,8 @@ typedef enum Conn_State
   }
 Conn_State;
 
+struct local_addr;
+
 typedef struct Conn
   {
     Object obj;
@@ -92,6 +94,7 @@ typedef struct Conn
     int port;			/* server's port (or -1 for default) */
     int	sd;			/* socket descriptor */
     int myport;			/* local port number or -1 */
+    struct local_addr *myaddr;
     /* Since replies are read off the socket sequentially, much of the
        reply-processing related state can be kept here instead of in
        the reply structure: */
@@ -99,6 +102,8 @@ typedef struct Conn
     size_t content_length;	/* content length (or INF if unknown) */
     u_int has_body : 1;		/* does reply have a body? */
     u_int is_chunked : 1;	/* is the reply chunked? */
+    u_int reading : 1;
+    u_int writing : 1;
     char line_buf[MAX_HDR_LINE_LEN];	/* default line buffer */
 
 #ifdef HAVE_SSL
@@ -109,6 +114,9 @@ Conn;
 
 extern int max_num_conn;
 extern Conn *conn;
+
+/* Store the servers to connect to in memory. */
+extern void conn_add_servers (void);
 
 /* Initialize the new connection object C.  */
 extern void conn_init (Conn *c);

--- a/src/core.h
+++ b/src/core.h
@@ -36,7 +36,8 @@
 #include <netinet/in.h>
 
 extern void core_init (void);
-extern struct sockaddr_in *core_intern_addr (const char *hostname,
+extern void core_add_addresses (const char *spec);
+extern struct sockaddr_in *core_addr_intern (const char *hostname,
 					     size_t hostname_len, int port);
 extern int core_connect (Conn *conn);
 extern int core_send (Conn *conn, Call *call);

--- a/src/httperf.h
+++ b/src/httperf.h
@@ -91,21 +91,22 @@ Rate_Info;
 typedef struct Cmdline_Params
   {
     int http_version;	/* (default) HTTP protocol version */
-    const char *server;	/* (default) hostname */
-    const char *server_name; /* fully qualified server name */
+    const char *server;
     int port;		/* (default) server port */
     const char *uri;	/* (default) uri */
+    const char *myaddr;
     Rate_Info rate;
     Time timeout;	/* watchdog timeout */
     Time think_timeout;	/* timeout for server think time */
-    int num_conns;	/* # of connections to generate */
-    int num_calls;	/* # of calls to generate per connection */
-    int burst_len;	/* # of calls to burst back-to-back */
-    int max_piped;	/* max # of piped calls per connection */
-    int max_conns;	/* max # of connections per session */
+    Time runtime;	/* how long to run the test */
+    u_long num_conns;	/* # of connections to generate */
+    u_long num_calls;	/* # of calls to generate per connection */
+    u_long burst_len;	/* # of calls to burst back-to-back */
+    u_long max_piped;	/* max # of piped calls per connection */
+    u_long max_conns;	/* max # of connections per session */
     int hog;		/* client may hog as much resources as possible */
-    int send_buffer_size;
-    int recv_buffer_size;
+    u_long send_buffer_size;
+    u_long recv_buffer_size;
     int failure_status;	/* status code that should be considered failure */
     int retry_on_failure; /* when a call fails, should we retry? */
     int close_with_reset; /* close connections with TCP RESET? */
@@ -120,6 +121,7 @@ typedef struct Cmdline_Params
 #endif
     int use_timer_cache;
     const char *additional_header;	/* additional request header(s) */
+    const char *additional_header_file;
     const char *method;	/* default call method */
     struct
       {
@@ -146,7 +148,7 @@ typedef struct Cmdline_Params
 	u_int num_reqs;		/* # of user requests per session */
 	Time think_time;	/* user think time between requests */
       }
-    wsesspage;
+    wsesspage;		/* XXX Currently broken */
     struct
       {
 	u_int num_sessions;	/* # of user-sessions */
@@ -165,6 +167,7 @@ Cmdline_Params;
 
 extern const char *prog_name;
 extern int verbose;
+extern int periodic_stats;
 extern Cmdline_Params param;
 extern Time test_time_start;
 extern Time test_time_stop;

--- a/src/timer.c
+++ b/src/timer.c
@@ -240,7 +240,7 @@ timer_schedule(void (*timeout) (struct Timer * t, Any_Type arg),
 	t->time_started = timer_now();
 	t->timeout_delay = delay;
 
-	if (delay > 0)
+	if (delay > 0 || true)
 	{
 		Any_Type temp;
 		temp.vp = (void *)t;


### PR DESCRIPTION
* Fix some corner cases with greedy mode, where ports would be
  tracked inside httperf rather than the OS.  There were handfuls
  of corner cases where it'd either loop over an already-allocated
  port by the OS and chew 100% of cpu with no progress. Also, hit an
  already allocated port by the OS, skip/stop, but then the next lookup
  would hit that port again - it would never find a new port to open.

* Add kqueue support for FreeBSD. (No, not using libevent. Yet.)

* Add a periodic stats option, to print out 200/302 counts once
  every second.  This is to aid in automatic scripts looking to graph
  the progress being made.

* Add the ability to define multiple local client addresses, so
  requests can come from a much bigger pool of IP addresses.
  This allows for much more concurrency per process.)

* Add an explicit timeout on how long httperf can run - again, to aid
  in automated testing.

* Add an option to allow header contents to be loaded in from a file.

* Other fixes, mostly type related fixes, thanks to clang/llvm on
  FreeBSD-10.

We're using this in production at Norse to stress test out things,
upwards of 25,000 requests per second per httperf process.