### PR TITLE
Patch to enable compilation with m4

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,2 +1,3 @@
 AUTOMAKE_OPTIONS = foreign
 SUBDIRS = src man
+ACLOCAL_AMFLAGS = -I m4

--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,8 @@ AC_INIT(httperf, 0.9.1, httperf@linux.hpl.hp.com)
 AC_CONFIG_SRCDIR([src/httperf.c])
 AC_CONFIG_HEADER([config.h])
 
+AC_CONFIG_MACRO_DIR([m4])
+
 AC_CANONICAL_TARGET
 
 AM_INIT_AUTOMAKE(httperf, 0.9.1)


### PR DESCRIPTION
Perform this before configure.

$ libtoolize --force
$ aclocal
$ autoheader
$ automake --force-missing --add-missing
$ autoconf
$ ./configure