### PR TITLE
Fix build without SSLv3

### DIFF
--- a/src/httperf.c
+++ b/src/httperf.c
@@ -66,7 +66,7 @@
 
 #ifdef __FreeBSD__
 /* Required for fpsetmask() under FreeBSD */
-#include <ieeefp.h>
+#include <machine/floatingpoint.h>
 #endif
 
 #include <sys/time.h>
@@ -947,7 +947,12 @@ main(int argc, char **argv)
 		 * for some strange reason, SSLv23_client_method () doesn't
 		 * work here 
 		 */
+#ifndef OPENSSL_NO_SSL3
 		ssl_ctx = SSL_CTX_new(SSLv3_client_method());
+#else
+		ssl_ctx = SSL_CTX_new(SSLv23_client_method());
+		SSL_CTX_set_options (ssl_ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 );
+#endif
 		if (!ssl_ctx) {
 			ERR_print_errors_fp(stderr);
 			exit(-1);


### PR DESCRIPTION
If the OpenSSL libraries have been built without SSLv3 support (--no-ssl3) httperf will fail to build as it requires SSLv3_ methods. This patch fixes the build error.

Additionally I've added an replaced the ieeefp include for FreeBSD with the machine/floatingpoint.h as was added for 0.8 in FreeBSD port.