### PR TITLE
Stray line feed in fqdname

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -112,6 +112,7 @@ conn_init(Conn *conn)
 	conn->sd = -1;
 	conn->myport = -1;
 	conn->line.iov_base = conn->line_buf;
+	conn->fqdname_len = strcspn(conn->fqdname,"\r\n"); // Chomp since used in Host header record
 
 #ifdef HAVE_SSL
 	if (param.use_ssl) {


### PR DESCRIPTION
Stray line feed in fqdname causes --add-header and --add-header-file argument 
header records to be ignored by server.

Having an cr and or lf within the IO vector entries IE_HOST and IE_NEWLINE1 cases server to stop processing request headers.
