### PR TITLE
Restore the original --server and --server_name options

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -86,22 +86,32 @@ conn_add_servers(void)
 void
 conn_init(Conn *conn)
 {
-	int len;
+	if (param.servers) {
+		int len = strlen(srvcurrent);
+		conn->hostname = srvcurrent;
+		conn->hostname_len = len;
+		conn->fqdname = conn->hostname;
+		conn->fqdname_len = conn->hostname_len;
 
-	len = strlen(srvcurrent);
-	conn->hostname = srvcurrent;
-	conn->hostname_len = len;
-
-	srvcurrent += len + 1;
-	if (srvcurrent >= srvend)
-		srvcurrent = srvbase;
+		srvcurrent += len + 1;
+		if (srvcurrent >= srvend)
+			srvcurrent = srvbase;
+	} else if (param.server_name) {
+		conn->hostname = param.server;
+		conn->hostname_len = strlen(param.server);
+		conn->fqdname = param.server_name;
+		conn->fqdname_len = strlen(param.server_name);
+	} else {
+		conn->hostname = param.server;
+		conn->hostname_len = strlen(param.server);
+		conn->fqdname = conn->hostname;
+		conn->fqdname_len = conn->hostname_len;
+	}
 
 	conn->port = param.port;
 	conn->sd = -1;
 	conn->myport = -1;
 	conn->line.iov_base = conn->line_buf;
-	conn->fqdname = conn->hostname;
-	conn->fqdname_len = conn->hostname_len;
 
 #ifdef HAVE_SSL
 	if (param.use_ssl) {

--- a/src/conn.c
+++ b/src/conn.c
@@ -1,35 +1,35 @@
 /*
-    httperf -- a tool for measuring web server performance
-    Copyright 2000-2007 Hewlett-Packard Company
-
-    This file is part of httperf, a web server performance measurment
-    tool.
-
-    This program is free software; you can redistribute it and/or
-    modify it under the terms of the GNU General Public License as
-    published by the Free Software Foundation; either version 2 of the
-    License, or (at your option) any later version.
-    
-    In addition, as a special exception, the copyright holders give
-    permission to link the code of this work with the OpenSSL project's
-    "OpenSSL" library (or with modified versions of it that use the same
-    license as the "OpenSSL" library), and distribute linked combinations
-    including the two.  You must obey the GNU General Public License in
-    all respects for all of the code used other than "OpenSSL".  If you
-    modify this file, you may extend this exception to your version of the
-    file, but you are not obligated to do so.  If you do not wish to do
-    so, delete this exception statement from your version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  
-    02110-1301, USA
-*/
+ * httperf -- a tool for measuring web server performance
+ * Copyright 2000-2007 Hewlett-Packard Company
+ *
+ * This file is part of httperf, a web server performance measurment
+ * tool.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * In addition, as a special exception, the copyright holders give
+ * permission to link the code of this work with the OpenSSL project's
+ * "OpenSSL" library (or with modified versions of it that use the same
+ * license as the "OpenSSL" library), and distribute linked combinations
+ * including the two.  You must obey the GNU General Public License in
+ * all respects for all of the code used other than "OpenSSL".  If you
+ * modify this file, you may extend this exception to your version of the
+ * file, but you are not obligated to do so.  If you do not wish to do
+ * so, delete this exception statement from your version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA
+ */
 
 #include "config.h"
 
@@ -56,7 +56,7 @@
 static char *srvbase, *srvend, *srvcurrent;
 
 void
-conn_add_servers (void)
+conn_add_servers(void)
 {
 	struct stat st;
 	int fd, len;
@@ -73,7 +73,7 @@ conn_add_servers (void)
 	if (srvbase == (char *)-1)
 		panic("%s: can't mmap the file: %s\n", prog_name, strerror(errno));
 
-	close (fd);
+	close(fd);
 
 	srvend = srvbase + st.st_size;
 	for (srvcurrent = srvbase; srvcurrent < srvend; srvcurrent += len + 1) {
@@ -84,7 +84,7 @@ conn_add_servers (void)
 }
 
 void
-conn_init (Conn *conn)
+conn_init(Conn *conn)
 {
 	int len;
 
@@ -112,7 +112,7 @@ conn_init (Conn *conn)
 		}
 
 		if (param.ssl_cipher_list) {
-			/* set order of ciphers  */
+			/* set order of ciphers */
 			int ssl_err = SSL_set_cipher_list(conn->ssl, param.ssl_cipher_list);
 
 			if (DBG > 2)
@@ -125,16 +125,16 @@ conn_init (Conn *conn)
 }
 
 void
-conn_deinit (Conn *conn)
+conn_deinit(Conn *conn)
 {
-  assert (conn->sd < 0 && conn->state != S_FREE);
-  assert (!conn->sendq);
-  assert (!conn->recvq);
-  assert (!conn->watchdog);
-  conn->state = S_FREE;
+	assert(conn->sd < 0 && conn->state != S_FREE);
+	assert(!conn->sendq);
+	assert(!conn->recvq);
+	assert(!conn->watchdog);
+	conn->state = S_FREE;
 
 #ifdef HAVE_SSL
-  if (param.use_ssl)
-    SSL_free (conn->ssl);
+	if (param.use_ssl)
+		SSL_free(conn->ssl);
 #endif
 }

--- a/src/conn.c
+++ b/src/conn.c
@@ -61,13 +61,13 @@ conn_add_servers(void)
 	struct stat st;
 	int fd, len;
 
-	fd = open(param.server, O_RDONLY, 0);
+	fd = open(param.servers, O_RDONLY, 0);
 	if (fd == -1)
-		panic("%s: can't open %s\n", prog_name, param.server);
+		panic("%s: can't open %s\n", prog_name, param.servers);
 
 	fstat(fd, &st);
 	if (st.st_size == 0)
-		panic("%s: file %s is empty\n", prog_name, param.server);
+		panic("%s: file %s is empty\n", prog_name, param.servers);
 
 	srvbase = (char *)mmap(0, st.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
 	if (srvbase == (char *)-1)

--- a/src/core.c
+++ b/src/core.c
@@ -963,7 +963,7 @@ core_init(void)
 		printf("%s: maximum number of open descriptors = %ld\n",
 		       prog_name, rlimit.rlim_max);
 
-	if (param.server)
+	if (param.servers)
 		conn_add_servers();
 	if (param.runtime) {
 		arg.l = 0;

--- a/src/core.c
+++ b/src/core.c
@@ -965,6 +965,9 @@ core_init(void)
 
 	if (param.servers)
 		conn_add_servers();
+	else if (param.server)
+		core_addr_intern(param.server, strlen(param.server), param.port);
+
 	if (param.runtime) {
 		arg.l = 0;
 		timer_schedule(core_runtime_timer, arg, param.runtime);

--- a/src/httperf.c
+++ b/src/httperf.c
@@ -136,7 +136,7 @@ static struct option longopts[] = {
 	{"retry-on-failure", no_argument, &param.retry_on_failure, 1},
 	{"runtime", required_argument, (int *) &param.runtime, 0},
 	{"send-buffer", required_argument, (int *) &param.send_buffer_size, 0},
-	{"server", required_argument, (int *) &param.server, 0},
+	{"servers", required_argument, (int *) &param.servers, 0},
 	{"uri", required_argument, (int *) &param.uri, 0},
 	{"session-cookies", no_argument, (int *) &param.session_cookies, 1},
 #ifdef HAVE_SSL
@@ -177,7 +177,7 @@ usage(void)
 	       "\t[--print-reply [header|body]] [--print-request [header|body]]\n"
 	       "\t[--rate X] [--recv-buffer N] [--retry-on-failure] "
 	       "[--send-buffer N]\n"
-	       "\t<--server file> [--port N] [--uri S] [--myaddr S]\n"
+	       "\t<--servers file> [--port N] [--uri S] [--myaddr S]\n"
 #ifdef HAVE_SSL
 	       "\t[--ssl] [--ssl-ciphers L] [--ssl-no-reuse]\n"
                "\t[--ssl-certificate file] [--ssl-key file]\n"
@@ -635,8 +635,8 @@ main(int argc, char **argv)
 						prog_name, optarg);
 					exit(1);
 				}
-			} else if (flag == &param.server)
-				param.server = optarg;
+			} else if (flag == &param.servers)
+				param.servers = optarg;
 #ifdef HAVE_SSL
 			else if (flag == &param.ssl_cipher_list)
 				param.ssl_cipher_list = optarg;
@@ -974,9 +974,9 @@ main(int argc, char **argv)
 		}
 	}
 
-	if (param.server == NULL) {
+	if (param.servers == NULL) {
 		fprintf(stderr,
-			"%s: must specify --server\n",
+			"%s: must specify --servers\n",
 			prog_name);
 		exit(-1);
 	}
@@ -1131,8 +1131,8 @@ main(int argc, char **argv)
 	if (param.runtime > 0)
 		printf(" --runtime=%g", param.runtime);
 	printf(" --client=%u/%u", param.client.id, param.client.num_clients);
-	if (param.server)
-		printf(" --server=%s", param.server);
+	if (param.servers)
+		printf(" --servers=%s", param.servers);
 	if (param.port)
 		printf(" --port=%d", param.port);
 	if (param.uri)

--- a/src/httperf.c
+++ b/src/httperf.c
@@ -136,6 +136,8 @@ static struct option longopts[] = {
 	{"retry-on-failure", no_argument, &param.retry_on_failure, 1},
 	{"runtime", required_argument, (int *) &param.runtime, 0},
 	{"send-buffer", required_argument, (int *) &param.send_buffer_size, 0},
+	{"server", required_argument, (int *) &param.server, 0},
+	{"server-name", required_argument, (int *) &param.server_name, 0},
 	{"servers", required_argument, (int *) &param.servers, 0},
 	{"uri", required_argument, (int *) &param.uri, 0},
 	{"session-cookies", no_argument, (int *) &param.session_cookies, 1},
@@ -175,9 +177,9 @@ usage(void)
 	       "\t[--num-calls N] [--num-conns N] [--session-cookies]\n"
 	       "\t[--period [d|u|e]T1[,T2]|[v]T1,D1[,T2,D2]...[,Tn,Dn]\n"
 	       "\t[--print-reply [header|body]] [--print-request [header|body]]\n"
-	       "\t[--rate X] [--recv-buffer N] [--retry-on-failure] "
-	       "[--send-buffer N]\n"
-	       "\t<--servers file> [--port N] [--uri S] [--myaddr S]\n"
+	       "\t[--rate X] [--recv-buffer N] [--retry-on-failure] [--send-buffer N]\n"
+	       "\t[--server S|--servers file] [--server-name S] [--port N] [--uri S] "
+	       "[--myaddr S]\n"
 #ifdef HAVE_SSL
 	       "\t[--ssl] [--ssl-ciphers L] [--ssl-no-reuse]\n"
                "\t[--ssl-certificate file] [--ssl-key file]\n"
@@ -635,7 +637,11 @@ main(int argc, char **argv)
 						prog_name, optarg);
 					exit(1);
 				}
-			} else if (flag == &param.servers)
+			} else if (flag == &param.server)
+				param.server = optarg;
+			else if (flag == &param.server_name)
+				param.server_name = optarg;
+			else if (flag == &param.servers)
 				param.servers = optarg;
 #ifdef HAVE_SSL
 			else if (flag == &param.ssl_cipher_list)
@@ -974,12 +980,15 @@ main(int argc, char **argv)
 		}
 	}
 
-	if (param.servers == NULL) {
+	if (param.server != NULL && param.servers != NULL) {
 		fprintf(stderr,
-			"%s: must specify --servers\n",
+			"%s: --server S or --servers file\n",
 			prog_name);
 		exit(-1);
 	}
+
+	if (param.server == NULL && param.servers == NULL)
+		param.server = "localhost";
 
 #ifdef HAVE_SSL
 	if (param.use_ssl) {
@@ -1131,6 +1140,10 @@ main(int argc, char **argv)
 	if (param.runtime > 0)
 		printf(" --runtime=%g", param.runtime);
 	printf(" --client=%u/%u", param.client.id, param.client.num_clients);
+	if (param.server)
+		printf(" --server=%s", param.server);
+	if (param.server_name)
+		printf(" --server_name=%s", param.server_name);
 	if (param.servers)
 		printf(" --servers=%s", param.servers);
 	if (param.port)

--- a/src/httperf.h
+++ b/src/httperf.h
@@ -91,7 +91,9 @@ Rate_Info;
 typedef struct Cmdline_Params
   {
     int http_version;	/* (default) HTTP protocol version */
-    const char *server;
+    const char *server;	/* (default) hostname */
+    const char *server_name; /* fully qualified server name */
+    const char *servers;
     int port;		/* (default) server port */
     const char *uri;	/* (default) uri */
     const char *myaddr;

--- a/src/httperf.h
+++ b/src/httperf.h
@@ -156,7 +156,7 @@ typedef struct Cmdline_Params
 	u_int num_reqs;		/* # of user requests per session */
 	Time think_time;	/* user think time between requests */
       }
-    wsesspage;		/* XXX Currently broken */
+    wsesspage;
     struct
       {
 	u_int num_sessions;	/* # of user-sessions */


### PR DESCRIPTION
At Norse I modified the --server option to accept a file that contained servers to connect to. This broke the original --server and --server_name options, so I had them removed (which was fine for us at Norse). Unfortunately, this broken behavior was upstreamed (and has bit some users). This pull request reinstates the original --server and --server_name options and creates a new option, --servers, which accepts a file of servers to connect to in a round robin fashion.