### PR TITLE
Fix errors building against OpenSSL 1.1.0.

### DIFF
--- a/src/httperf.c
+++ b/src/httperf.c
@@ -680,7 +680,7 @@ main(int argc, char **argv)
 #endif
                             else if (strcasecmp (optarg, "TLSv1") == 0)
                                 param.ssl_protocol = 4;
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+#if (OPENSSL_VERSION_NUMBER >= 0x10101000L)
                             else if (strcasecmp (optarg, "TLSv1_3") == 0)
                                 param.ssl_protocol = 5;
 #endif
@@ -1029,8 +1029,11 @@ main(int argc, char **argv)
                     case 2: 
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
                     ssl_ctx = SSL_CTX_new (TLS_client_method ());
-                    SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1 | SSL_OP_NO_TLSv1_2 | SSL_OP_NO_TLSv1_3);
-break;
+#if (OPENSSL_VERSION_NUMBER >= 0x10101000L)
+                    SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1 | SSL_OP_NO_TLSv1_2 | SSL_OP_NO_TLSv1_3); break;
+#else
+                    SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1 | SSL_OP_NO_TLSv1_2); break;
+#endif
 #else
                     ssl_ctx = SSL_CTX_new (SSLv2_client_method ()); break;
 #endif
@@ -1041,8 +1044,11 @@ break;
                     case 3: 
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
                     ssl_ctx = SSL_CTX_new (TLS_client_method ());
-                    SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1 | SSL_OP_NO_TLSv1_2 | SSL_OP_NO_TLSv1_3);
-break;
+#if (OPENSSL_VERSION_NUMBER >= 0x10101000L)
+                    SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1 | SSL_OP_NO_TLSv1_2 | SSL_OP_NO_TLSv1_3); break;
+#else
+                    SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1 | SSL_OP_NO_TLSv1_2); break;
+#endif
 #else
                     ssl_ctx = SSL_CTX_new (SSLv3_client_method ()); break;
 #endif
@@ -1056,7 +1062,7 @@ break;
                     ssl_ctx = SSL_CTX_new (TLSv1_client_method ()); break;
 #endif
 
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+#if (OPENSSL_VERSION_NUMBER >= 0x10101000L)
                     /* 5/TLSv1_3 */
                     case 5: ssl_ctx = SSL_CTX_new (TLS_client_method ()); 
                     SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1 | SSL_OP_NO_TLSv1_2); break;
@@ -1273,7 +1279,7 @@ break;
             case 3: printf (" --ssl-protocol=SSLv3"); break;
 #endif
             case 4: printf (" --ssl-protocol=TLSv1"); break;
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+#if (OPENSSL_VERSION_NUMBER >= 0x10101000L)
             case 5: printf (" --ssl-protocol=TLSv1_3"); break;
 #endif
         }


### PR DESCRIPTION
Changed #57, which doesn't work for me, to successfully fix #54.

As OpenSSL 1.1.0 does neither know `SSLv2_client_method` **nor** `SSL_OP_NO_TLSv1_3`, more complicated conditionals are needed.

Caveat: compiles fine, but it is not thoroughly tested.