### PR TITLE
Fix build errors in OpenSSL 1.1.0 and several other improvements . Done for IETF 102 hackathon.

### DIFF
--- a/src/httperf.c
+++ b/src/httperf.c
@@ -1064,6 +1064,18 @@ main(int argc, char **argv)
 		    SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1_1 | SSL_OP_NO_TLSv1_2); break;
 #endif
 
+                    /* 5/TLSv1.1 */
+                    case 5:
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+                    ssl_ctx = SSL_CTX_new (TLS_client_method ());
+                    SSL_CTX_set_min_proto_version(ssl_ctx, TLS1_1_VERSION);
+		    SSL_CTX_set_max_proto_version(ssl_ctx, TLS1_1_VERSION);
+		    break;
+#else
+                    ssl_ctx = SSL_CTX_new (TLSv1_client_method ()); break;
+		    SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_2); break;
+#endif
+
                 }
       
 		if (!ssl_ctx) {

--- a/src/httperf.c
+++ b/src/httperf.c
@@ -680,10 +680,6 @@ main(int argc, char **argv)
 #endif
                             else if (strcasecmp (optarg, "TLSv1") == 0)
                                 param.ssl_protocol = 4;
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
-                            else if (strcasecmp (optarg, "TLSv1_3") == 0)
-                                param.ssl_protocol = 5;
-#endif
                             else
                             {
                                 fprintf (stderr, "%s: illegal SSL protocol %s\n",
@@ -1026,7 +1022,7 @@ main(int argc, char **argv)
                     case 2: 
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
                     ssl_ctx = SSL_CTX_new (TLS_client_method ());
-                    SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1 | SSL_OP_NO_TLSv1_2 | SSL_OP_NO_TLSv1_3);
+                    SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1 | SSL_OP_NO_TLSv1_2);
 break;
 #else
                     ssl_ctx = SSL_CTX_new (SSLv2_client_method ()); break;
@@ -1038,7 +1034,7 @@ break;
                     case 3: 
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
                     ssl_ctx = SSL_CTX_new (TLS_client_method ());
-                    SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1 | SSL_OP_NO_TLSv1_2 | SSL_OP_NO_TLSv1_3);
+                    SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1 | SSL_OP_NO_TLSv1_2);
 break;
 #else
                     ssl_ctx = SSL_CTX_new (SSLv3_client_method ()); break;
@@ -1053,11 +1049,6 @@ break;
                     ssl_ctx = SSL_CTX_new (TLSv1_client_method ()); break;
 #endif
 
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
-                    /* 5/TLSv1_3 */
-                    case 5: ssl_ctx = SSL_CTX_new (TLS_client_method ()); 
-                    SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1 | SSL_OP_NO_TLSv1_2); break;
-#endif
                 }
       
 		if (!ssl_ctx) {
@@ -1270,9 +1261,6 @@ break;
             case 3: printf (" --ssl-protocol=SSLv3"); break;
 #endif
             case 4: printf (" --ssl-protocol=TLSv1"); break;
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
-            case 5: printf (" --ssl-protocol=TLSv1_3"); break;
-#endif
         }
 #endif
 	if (param.additional_header)

--- a/src/httperf.c
+++ b/src/httperf.c
@@ -1030,8 +1030,11 @@ main(int argc, char **argv)
                     case 2: 
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
                     ssl_ctx = SSL_CTX_new (TLS_client_method ());
-                    SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1 | SSL_OP_NO_TLSv1_2);
-break;
+#if (OPENSSL_VERSION_NUMBER >= 0x10101000L)
+                    SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1 | SSL_OP_NO_TLSv1_2 | SSL_OP_NO_TLSv1_3); break;
+#else
+		    SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1 | SSL_OP_NO_TLSv1_2); break;
+#endif
 #else
                     ssl_ctx = SSL_CTX_new (SSLv2_client_method ()); break;
 #endif

--- a/src/httperf.c
+++ b/src/httperf.c
@@ -1045,8 +1045,9 @@ main(int argc, char **argv)
                     case 3: 
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
                     ssl_ctx = SSL_CTX_new (TLS_client_method ());
-                    SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1 | SSL_OP_NO_TLSv1_2);
-break;
+		    SSL_CTX_set_min_proto_version(ssl_ctx, SSL3_VERSION);
+		    SSL_CTX_set_max_proto_version(ssl_ctx, SSL3_VERSION);
+		    break;
 #else
                     ssl_ctx = SSL_CTX_new (SSLv3_client_method ()); break;
 #endif

--- a/src/httperf.c
+++ b/src/httperf.c
@@ -1088,6 +1088,14 @@ main(int argc, char **argv)
 		    SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1); break;
 #endif
 
+#if (OPENSSL_VERSION_NUMBER >= 0x10101000L)
+                    /* 7/TLSv1.3 */
+                    ssl_ctx = SSL_CTX_new (TLS_client_method ());
+                    SSL_CTX_set_min_proto_version(ssl_ctx, TLS1_3_VERSION);
+		    SSL_CTX_set_max_proto_version(ssl_ctx, TLS1_3_VERSION);
+		    break;
+#endif
+
                 }
       
 		if (!ssl_ctx) {

--- a/src/httperf.c
+++ b/src/httperf.c
@@ -678,8 +678,16 @@ main(int argc, char **argv)
                             else if (strcasecmp (optarg, "SSLv3") == 0)
                                 param.ssl_protocol = 3;
 #endif
-                            else if (strcasecmp (optarg, "TLSv1") == 0)
+                            else if (strcasecmp (optarg, "TLSv1.0") == 0 || strcasecmp (optarg, "TLSv1_0") == 0 || strcasecmp (optarg, "TLSv1") == 0)
                                 param.ssl_protocol = 4;
+			    else if (strcasecmp (optarg, "TLSv1.1") == 0 || strcasecmp (optarg, "TLSv1_1") == 0)
+                                param.ssl_protocol = 5;
+			    else if (strcasecmp (optarg, "TLSv1.2") == 0 || strcasecmp (optarg, "TLSv1_2") == 0)
+                                param.ssl_protocol = 6;
+#if (OPENSSL_VERSION_NUMBER >= 0x10101000L)
+                            else if (strcasecmp (optarg, "TLSv1.3") == 0 || strcasecmp (optarg, "TLSv1_3") == 0)
+                                param.ssl_protocol = 7;
+#endif
                             else
                             {
                                 fprintf (stderr, "%s: illegal SSL protocol %s\n",
@@ -1260,7 +1268,12 @@ break;
 #ifndef OPENSSL_NO_SSL3
             case 3: printf (" --ssl-protocol=SSLv3"); break;
 #endif
-            case 4: printf (" --ssl-protocol=TLSv1"); break;
+            case 4: printf (" --ssl-protocol=TLSv1.0"); break;
+	    case 5: printf (" --ssl-protocol=TLSv1.1"); break;
+	    case 6: printf (" --ssl-protocol=TLSv1.2"); break;
+#if (OPENSSL_VERSION_NUMBER >= 0x10101000L)
+            case 7: printf (" --ssl-protocol=TLSv1.3"); break;
+#endif
         }
 #endif
 	if (param.additional_header)

--- a/src/httperf.c
+++ b/src/httperf.c
@@ -1052,13 +1052,16 @@ main(int argc, char **argv)
                     ssl_ctx = SSL_CTX_new (SSLv3_client_method ()); break;
 #endif
 #endif
-                    /* 4/TLSv1 */
+                    /* 4/TLSv1.0 */
                     case 4: 
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
                     ssl_ctx = SSL_CTX_new (TLS_client_method ()); 
-                    SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3); break;
+                    SSL_CTX_set_min_proto_version(ssl_ctx, TLS1_VERSION);
+		    SSL_CTX_set_max_proto_version(ssl_ctx, TLS1_VERSION);
+		    break;
 #else
                     ssl_ctx = SSL_CTX_new (TLSv1_client_method ()); break;
+		    SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1_1 | SSL_OP_NO_TLSv1_2); break;
 #endif
 
                 }

--- a/src/httperf.c
+++ b/src/httperf.c
@@ -1007,12 +1007,9 @@ main(int argc, char **argv)
 
                 SSL_library_init ();
 		SSL_load_error_strings ();
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
-                OpenSSL_add_all_algorithms ();
-#else
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
                 SSLeay_add_all_algorithms ();
 #endif
-		SSLeay_add_ssl_algorithms ();
 
 		switch (param.ssl_protocol)
                 {

--- a/src/httperf.c
+++ b/src/httperf.c
@@ -1076,6 +1076,18 @@ main(int argc, char **argv)
 		    SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_2); break;
 #endif
 
+		    /* 6/TLSv1.2 */
+                    case 6:
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+                    ssl_ctx = SSL_CTX_new (TLS_client_method ());
+                    SSL_CTX_set_min_proto_version(ssl_ctx, TLS1_2_VERSION);
+		    SSL_CTX_set_max_proto_version(ssl_ctx, TLS1_2_VERSION);
+		    break;
+#else
+                    ssl_ctx = SSL_CTX_new (TLSv1_client_method ()); break;
+		    SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1); break;
+#endif
+
                 }
       
 		if (!ssl_ctx) {


### PR DESCRIPTION
- Optimize OpenSSL initialization by removing synonymous calls to SSL_library_init()

- Fix OpenSSL 1.1.0 build errors for TLS 1.3

- Provide the ability to select specific protocols for TLS 1.x through the _--ssl-protocol_ switch instead of just --ssl-protocol=TLSv1
For example: 

      --ssl-protocol=TLSv1.0

      --ssl-protocol=TLSv1.2

      --ssl-protocol=TLSv1.3


- Ensure future-proof code and improve protocol selection by using the new API _SSL_CTX_set_min_proto_version_ and _SSL_CTX_set_max_proto_version_ in OpenSSL >= 1.1.0 instead of the flags _SSL_OP_NO_SSLv*_ and _SSL_OP_NO_TLSv*_