### PR TITLE
Fix major bugs. Done during IETF 102 hackathon.

### DIFF
--- a/src/httperf.c
+++ b/src/httperf.c
@@ -1092,6 +1092,7 @@ main(int argc, char **argv)
 
 #if (OPENSSL_VERSION_NUMBER >= 0x10101000L)
                     /* 7/TLSv1.3 */
+		    case 7:
                     ssl_ctx = SSL_CTX_new (TLS_client_method ());
                     SSL_CTX_set_min_proto_version(ssl_ctx, TLS1_3_VERSION);
 		    SSL_CTX_set_max_proto_version(ssl_ctx, TLS1_3_VERSION);

--- a/src/httperf.c
+++ b/src/httperf.c
@@ -668,6 +668,8 @@ main(int argc, char **argv)
                                 param.ssl_ca_path = optarg;
                         else if (flag == &param.ssl_protocol)
                         {
+			    param.use_ssl = 1;
+
                             if (strcasecmp (optarg, "auto") == 0)
                                 param.ssl_protocol = 0;
 #ifndef OPENSSL_NO_SSL2

--- a/src/httperf.c
+++ b/src/httperf.c
@@ -1062,7 +1062,7 @@ main(int argc, char **argv)
 		    SSL_CTX_set_max_proto_version(ssl_ctx, TLS1_VERSION);
 		    break;
 #else
-                    ssl_ctx = SSL_CTX_new (TLSv1_client_method ()); break;
+                    ssl_ctx = SSL_CTX_new (TLSv1_client_method ());
 		    SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1_1 | SSL_OP_NO_TLSv1_2); break;
 #endif
 
@@ -1074,7 +1074,7 @@ main(int argc, char **argv)
 		    SSL_CTX_set_max_proto_version(ssl_ctx, TLS1_1_VERSION);
 		    break;
 #else
-                    ssl_ctx = SSL_CTX_new (TLSv1_client_method ()); break;
+                    ssl_ctx = SSL_CTX_new (TLSv1_client_method ());
 		    SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_2); break;
 #endif
 
@@ -1086,7 +1086,7 @@ main(int argc, char **argv)
 		    SSL_CTX_set_max_proto_version(ssl_ctx, TLS1_2_VERSION);
 		    break;
 #else
-                    ssl_ctx = SSL_CTX_new (TLSv1_client_method ()); break;
+                    ssl_ctx = SSL_CTX_new (TLSv1_client_method ());
 		    SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1); break;
 #endif
 


### PR DESCRIPTION
- Fixed bug that caused the _SSL_CTX_set_options_ function for the TLSv1.x implementations to be ignored due to an extra 'break;' statement. (This was a typo introduced in my last commit. Sorry about that!)

- Fixed bug that prevented the TLSv1.3 implementation code from being reached due to a missing 'case' statement. (This was a typo introduced in my last commit. Sorry about that!)

- Fixed a major bug that that disregards any valid protocol specified by the -_-ssl-protocol_ parameter. This bug has been present since December 2015 ( see pull #24 ) and was discovered through packet analysis using Wireshark.