### PR TITLE
Add support for Server Name Indication. Done during IETF 103 hackathon

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -122,6 +122,11 @@ conn_init(Conn *conn)
 			exit(-1);
 		}
 
+		if (param.tls_server_name)
+		{
+			SSL_set_tlsext_host_name(conn->ssl, param.tls_server_name);
+		}
+		
 		if (param.ssl_cipher_list) {
 			/* set order of ciphers */
 			int ssl_err = SSL_set_cipher_list(conn->ssl, param.ssl_cipher_list);

--- a/src/httperf.c
+++ b/src/httperf.c
@@ -144,6 +144,7 @@ static struct option longopts[] = {
 #ifdef HAVE_SSL
 	{"ssl", no_argument, &param.use_ssl, 1},
 	{"ssl-ciphers", required_argument, (int *) &param.ssl_cipher_list, 0},
+	{"tls-server-name", required_argument, (int *) &param.tls_server_name, 0},
 	{"ssl-no-reuse", no_argument, &param.ssl_reuse, 0},
         {"ssl-certificate", required_argument, (int *) &param.ssl_cert,     0},
         {"ssl-key",      required_argument, (int *) &param.ssl_key,         0},
@@ -697,6 +698,19 @@ main(int argc, char **argv)
                                 exit (1);
                             }
                         }
+						else if (flag == &param.tls_server_name)
+						{
+							if (param.ssl_protocol >= 4)
+							{
+								param.tls_server_name = optarg;
+							}
+							else
+                            {
+                                fprintf (stderr, "%s: Error setting the SNI (Server Name Indication) server name to %s. The --tls-server-name option can only be used if --ssl-protocol-version is set to TLSv1.0 and above.\n",
+                                        prog_name, optarg);
+                                exit (1);
+                            }
+						}
 #endif
 			else if (flag == &param.uri)
 				param.uri = optarg;
@@ -1294,6 +1308,8 @@ main(int argc, char **argv)
 		printf(" --ssl");
 	if (param.ssl_cipher_list)
 		printf(" --ssl-ciphers=%s", param.ssl_cipher_list);
+	if (param.tls_server_name)
+		printf(" --tls-server-name=%s", param.tls_server_name);
 	if (!param.ssl_reuse)
 		printf(" --ssl-no-reuse");
         if (param.ssl_cert) printf (" --ssl-cert=%s", param.ssl_cert);

--- a/src/httperf.h
+++ b/src/httperf.h
@@ -121,6 +121,7 @@ typedef struct Cmdline_Params
     int ssl_reuse;	/* reuse SSL Session ID */
     int ssl_verify;     /* whether to verify the server certificate */
     int ssl_protocol;   /* which SSL protocol to use */
+    const char *tls_server_name; /* TLS SNI (server name indication) */
     const char *ssl_cipher_list; /* client's list of SSL cipher suites */
     const char *ssl_cert; /* client certificate file name */
     const char *ssl_key; /* client key file name */


### PR DESCRIPTION
This patch adds support for SNI (Server Name Indication). The option _--tls-server-name_ has been added in order to specify the server name to be used in the SeverName extension sent in the ClientHello for TLS connections.

The newly added _--tls-server-name_ flag is optional: If not specified, httperf will simply function as usual by omitting the ServerName extension in the ClientHello for TLS connections.

Example usage:
`httperf --server github.com --port 443 --ssl-protocol=TLSv1.2 --tls-server-name github.com`

Closes: #47 