### PR TITLE
Fix segfault when a connection is failed by using epoll(7).

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -1446,9 +1446,11 @@ core_close(Conn * conn)
 
 		error = epoll_ctl(epoll_fd, EPOLL_CTL_DEL, sd, &ev);
 		if (error < 0) {
-			error = errno;
-			printf("EPOLL_CTL_DEL: %d %d %d\n", epoll_fd, sd, error);
-			assert(error == 0);
+			if (conn->epoll_added == 1 && error != ENOENT) {
+				error = errno;
+				printf("EPOLL_CTL_DEL: %d %d %d\n", epoll_fd, sd, error);
+				assert(error == 0);
+			}
 		}
 #endif
 		close(sd);


### PR DESCRIPTION
I found out my previous patch has a bug not to handle a socket in case of connection failure.